### PR TITLE
Fix: josetsu.vueでprops.area未定義時のエラーを防止

### DIFF
--- a/pages/josetsu.vue
+++ b/pages/josetsu.vue
@@ -178,8 +178,15 @@ const getCoordinates = async (area: string) => {
 }
 
 watch(() => props.area, async (newArea) => {
-  await getCoordinates(newArea);
-  await updateMapView();
+  if (newArea && typeof newArea === 'string' && newArea.trim() !== '') {
+    await getCoordinates(newArea);
+    await updateMapView();
+  } else {
+    // newArea が無効な場合、地図表示をクリアするなどの処理も検討できる
+    // coordinates.value = null; 
+    // if (map) { map.remove(); map = null; }
+    console.warn('props.area が無効なため、座標取得と地図更新をスキップしました。 area:', newArea);
+  }
 }, { immediate: true });
 
 onMounted(async () => {


### PR DESCRIPTION
pages/josetsu.vue において、props.area が未定義または無効な値の場合でも、初期表示時に getCoordinates 関数が呼び出され、「地域「undefined」の座標取得に失敗しました」というエラーが発生する問題を修正しました。

修正内容：
- `watch` コールバック内で `props.area` (newArea) の値をチェックし、有効な文字列である場合にのみ `getCoordinates` および `updateMapView` を実行するようにしました。
- `props.area` が無効な場合は、コンソールに警告メッセージを出力します。

これにより、意図しないエラーの発生を防ぎ、コンポーネントの安定性が向上します。