### PR TITLE
Debug: SnowLocationMapの座標取得処理に詳細ログを追加

### DIFF
--- a/components/SnowLocationMap.vue
+++ b/components/SnowLocationMap.vue
@@ -22,19 +22,28 @@ let mapInstance: any = null
  * 地域名から座標を取得する関数
  */
 async function getCoordinates(area: string) {
+  console.log(`[SnowLocationMap] getCoordinates called for area: '${area}'`);
   try {
     const query = `${area}、稚内市、北海道`
+    console.log(`[SnowLocationMap] Nominatim query: '${query}'`);
     const response = await fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}`)
     const data = await response.json()
+    console.log(`[SnowLocationMap] Nominatim response for '${area}':`, JSON.stringify(data, null, 2));
 
     if (data && data[0]) {
       coordinates.value = {
         lat: parseFloat(data[0].lat),
         lng: parseFloat(data[0].lon)
       }
+      console.log(`[SnowLocationMap] Coordinates updated for '${area}':`, coordinates.value);
+    } else {
+      console.warn(`[SnowLocationMap] No coordinates found for area: '${area}'. Using initial coordinates.`);
+      // オプション: 座標が見つからない場合、初期値やエラー状態に戻すことを検討
+      // coordinates.value = { lat: 45.4161, lng: 141.6739 }; // 例えば初期値に戻すか、あるいはnullなど
     }
   } catch (error) {
-    console.error('Geocoding error:', error)
+    console.error(`[SnowLocationMap] Geocoding error for area '${area}':`, error);
+    console.warn(`[SnowLocationMap] Geocoding failed for area: '${area}'. Using initial coordinates.`);
   }
 }
 


### PR DESCRIPTION
pages/josetsu.vue で表示される各地域の地図が、すべて同じ場所（稚内市中央と思われる初期座標）を指してしまう問題の調査のため、`components/SnowLocationMap.vue` の座標取得処理に詳細なデバッグログを追加しました。

この変更により、以下の点がコンソールで確認できるようになります：
- `getCoordinates` 関数がどの `area` で呼び出されたか
- Nominatim API への検索クエリ文字列
- Nominatim API からのレスポンス内容
- 座標が更新された場合、その新しい座標値
- 座標が見つからなかった、またはジオコーディングエラーが発生した場合の警告

ユーザーにこのブランチで動作確認を依頼し、コンソールログから問題のある `area` やAPIレスポンスを特定します。
ログ確認後、具体的な修正方針を決定します。