### PR TITLE
refactor: 型定義の厳格化（any型の排除）(Closes #7)

### DIFF
--- a/components/SnowLocationMap.vue
+++ b/components/SnowLocationMap.vue
@@ -8,6 +8,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
 import 'leaflet/dist/leaflet.css'
+import type { Map as LeafletMap } from 'leaflet'
 
 // 親から文字列プロパティ "area" を受け取る
 const props = defineProps<{
@@ -16,7 +17,7 @@ const props = defineProps<{
 
 // 座標の初期値を任意で設定
 const coordinates = ref({ lat: 45.4161, lng: 141.6739 })
-let mapInstance: any = null
+let mapInstance: LeafletMap | null = null
 
 /**
  * 地域名から座標を取得する関数

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -33,4 +33,4 @@ export default defineNuxtConfig({
       SUPABASE_KEY: process.env.SUPABASE_KEY
     }
   }
-} as any)
+})

--- a/server/api/snow/create.ts
+++ b/server/api/snow/create.ts
@@ -6,10 +6,37 @@ import { serverSupabaseClient } from '#supabase/server'
  */
 
 /**
+ * 除雪情報の型定義
+ * @interface SnowReport
+ */
+interface SnowReport {
+  /** 除雪情報の一意のID */
+  id: number
+  /** 除雪作業が行われた地域名 */
+  area: string
+  /** 除雪作業の開始時間 */
+  start_time: string
+  /** 除雪作業の終了時間 */
+  end_time: string
+  /** 作成日時 */
+  created_at?: string
+}
+
+/**
+ * API応答の型定義
+ * @interface ApiResponse
+ */
+interface ApiResponse {
+  success: boolean
+  data?: SnowReport[] | null
+  error?: string
+}
+
+/**
  * 新規除雪情報を作成するイベントハンドラー
  * @async
  * @param {H3Event} event - H3イベントオブジェクト
- * @returns {Promise<{success: boolean, data?: any, error?: string}>} 作成結果
+ * @returns {Promise<ApiResponse>} 作成結果
  */
 export default defineEventHandler(async (event) => {
   try {

--- a/server/api/snow/update.ts
+++ b/server/api/snow/update.ts
@@ -21,10 +21,20 @@ interface SnowReport {
 }
 
 /**
+ * API応答の型定義
+ * @interface ApiResponse
+ */
+interface ApiResponse {
+  success: boolean
+  data?: SnowReport[] | null
+  error?: string
+}
+
+/**
  * 除雪情報を更新するイベントハンドラー
  * @async
  * @param {H3Event} event - H3イベントオブジェクト
- * @returns {Promise<{success: boolean, data?: any, error?: string}>} 更新結果
+ * @returns {Promise<ApiResponse>} 更新結果
  */
 export default defineEventHandler(async (event) => {
   try {


### PR DESCRIPTION
## 概要
Issue #7 の解決として、プロジェクト内の型定義を厳格化しました。具体的には、`any` 型の使用箇所を特定し、より具体的な型定義に置き換えました。

## 変更内容
1. `components/SnowLocationMap.vue`:
   - `mapInstance: any` を `mapInstance: LeafletMap | null` に変更
   - Leafletの型定義を適切にインポート: `import type { Map as LeafletMap } from 'leaflet'`

2. `server/api/snow/update.ts`:
   - API応答の型定義に `any` が使われていたため、具体的な型定義 `ApiResponse` インターフェースを作成
   - `SnowReport` のコレクションを返すように型定義を明確化

3. `server/api/snow/create.ts`:
   - 同様に、`SnowReport` と `ApiResponse` インターフェースを追加
   - 戻り値の型を `Promise<ApiResponse>` に変更

4. `nuxt.config.ts`:
   - 不要な `as any` 型アサーションを削除

## 期待される成果
- TypeScriptの型チェックによる安全性の向上
- コードの可読性と保守性の向上
- リファクタリングや機能追加時の安全性向上
- IDEのコード補完機能の改善

## 確認事項
- アプリケーションの機能に影響を与えていないこと
- コンパイルエラーが発生していないこと