### PR TITLE
fix: InformationIconコンポーネントの表示エラーを修正

### DIFF
--- a/components/ui/InformationIcon.vue
+++ b/components/ui/InformationIcon.vue
@@ -1,27 +1,31 @@
 <template>
-    <div class="flex">
-        <!-- 画面情報表示部分 -->
-        <div class="w-full flex mt-4 mb-7 ml-2 mr-2 items-center justify-center">
-            <img
-                :src="iconSrc"
-                class="w-17 h-16 w-max-[67px] h-max-[67px] p-1 mr-3"
-                :alt="iconAlt"
-            />
-            <h1
-                :class="textColorClass"
-                class="text-5xl font-bold font-['Noto Sans']"
-            >
-                {{ title }}
-            </h1>
+    <!-- 画面情報表示部分 -->
+    <div class="w-full flex mt-4 mb-7 ml-2 mr-2 items-center justify-center">
+        <img
+            v-if="iconSrc"
+            :src="iconSrc"
+            class="w-16 h-16 max-w-[67px] max-h-[67px] p-1 mr-3"
+            :alt="iconAlt"
+            loading="lazy"
+        />
+        <div v-else class="w-16 h-16 max-w-[67px] max-h-[67px] p-1 mr-3 bg-blue-100 border border-gray-300 flex items-center justify-center text-xs text-gray-500">
+            アイコンなし
         </div>
+        <h1
+            :class="textColorClass"
+            class="text-5xl font-bold font-['Noto Sans']"
+        >
+            {{ title }}
+        </h1>
     </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 
-// 画像をインポート
-import josetsuIcon from '@/assets/img/josetsuImg/josetsuIcon.png'
+// 画像のパスを修正（Nuxt 3のassetsディレクトリから読み込み）
+import josetsuIconUrl from '~/assets/img/josetsuImg/josetsuIcon.png'
+const josetsuIcon = josetsuIconUrl
 
 // Props定義
 const props = withDefaults(defineProps<{
@@ -31,10 +35,7 @@ const props = withDefaults(defineProps<{
     iconAlt?: string
     textColor?: string
 }>(), {
-    type: 'default',
-    title: 'デフォルト情報',
-    iconAlt: 'アイコン',
-    textColor: 'text-[#000000]'
+    type: 'default'
 })
 
 // アイコン設定のマッピング

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,6 +9,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
+import InformationIcon from '~/components/ui/InformationIcon.vue'
 
 const route = useRoute()
 

--- a/pages/josetsu.vue
+++ b/pages/josetsu.vue
@@ -39,6 +39,11 @@
  * @vue-component
  */
 <script setup lang="ts">
+// ページメタ定義
+definePageMeta({
+  layout: 'default'
+})
+
 import { ref, computed, onMounted, watch, onBeforeUnmount } from 'vue'
 import { useSupabaseClient } from '#imports'
 import SnowLocationMap from '~/components/feature/snow/SnowLocationMap.vue'

--- a/types/assets.d.ts
+++ b/types/assets.d.ts
@@ -1,0 +1,29 @@
+declare module '*.png' {
+  const src: string
+  export default src
+}
+
+declare module '*.jpg' {
+  const src: string
+  export default src
+}
+
+declare module '*.jpeg' {
+  const src: string
+  export default src
+}
+
+declare module '*.gif' {
+  const src: string
+  export default src
+}
+
+declare module '*.svg' {
+  const src: string
+  export default src
+}
+
+declare module '*.webp' {
+  const src: string
+  export default src
+} 


### PR DESCRIPTION
## 修正内容

- InformationIcon.vue: Nuxt 3のassetsインポート方式に変更
- types/assets.d.ts: 画像ファイル型定義を追加  
- layouts/default.vue: コンポーネントの明示的インポート
- pages/josetsu.vue: レイアウト指定を追加

## 修正結果
- /josetsuページでInformationIconが正常表示
- 画像読み込みエラーを解消
- TypeScriptエラーを解消

refs #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * InformationIconコンポーネントがレイアウトに追加され、ルートに応じて動的に表示されるようになりました。

* **改善**
  * アイコン画像の表示が条件付きで最適化され、画像未指定時には「アイコンなし」と表示されるようになりました。
  * 画像の読み込みが遅延ロード（lazy loading）に対応しました。
  * 画像サイズのスタイルが統一されました。

* **開発体験**
  * 画像ファイルの型定義が追加され、TypeScriptで画像インポート時の型安全性が向上しました。

* **その他**
  * ページメタデータが追加され、レイアウト指定が明示的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->