### PR TITLE
fix(pages): snowlistページのレイアウト設定を修正 [refs #1]

### DIFF
--- a/pages/snowlist.vue
+++ b/pages/snowlist.vue
@@ -113,7 +113,7 @@
 
 <script setup lang="ts">
 
-definePageMeta({ layout: 'false' })
+definePageMeta({ layout: false })
 import { ref, onMounted } from 'vue'
 // import { serverSupabaseClient } from '#supabase/server' // serverSupabaseClientはクライアントサイドでは不要
 import { useRouter } from 'vue-router' // 追加


### PR DESCRIPTION
### 概要
snowlistページでコンソールに表示されていた「Invalid layout 'false' selected.」警告を修正しました。

### 変更内容
- \definePageMeta({ layout: 'false' })\を\definePageMeta({ layout: false })\に修正
- レイアウト設定で文字列ではなく適切なブール値を使用

### 修正理由
- Nuxt 3では\layout: false\（ブール値）が正しい設定
- 文字列'false'はInvalid layoutとして扱われていた

### 動作確認
- Playwright MCPでコンソールエラーをチェック済み
- 修正後、警告が完全に解消されることを確認

refs #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * レイアウトの無効化設定が文字列から真偽値に修正され、ページの表示が正しくなるよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->